### PR TITLE
enable r2modman support

### DIFF
--- a/LethalClunk.csproj
+++ b/LethalClunk.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -17,6 +17,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="Assembly-CSharp">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Assembly-CSharp.dll</HintPath>
+    </Reference>
     <Reference Include="deps\LC.dll" Private="false" />
   </ItemGroup>
   

--- a/Patches.cs
+++ b/Patches.cs
@@ -11,8 +11,9 @@ namespace LethalClunk.Patches
     [HarmonyPatch(typeof(GrabbableObject))]
     internal class FlashlightBopItPatch
     {
+        
         private static string clipName = "metal_bar.wav";
-        private static string path = Path.Combine(Paths.PluginPath + $"\\{PluginInfo.PLUGIN_NAME}\\");
+        private static string dllDirectory = Path.GetDirectoryName(Plugin.Instance.Info.Location) + "\\";
         private static ManualLogSource logger = BepInEx.Logging.Logger.CreateLogSource(PluginInfo.PLUGIN_NAME);
 
         [HarmonyPatch("Start")]
@@ -22,7 +23,7 @@ namespace LethalClunk.Patches
             var item = __instance.itemProperties;
             if (item.itemName == "Large axle")
             {
-                AudioClip audioClip = await LoadAudioClip(path + clipName);
+                AudioClip audioClip = await LoadAudioClip(dllPath + clipName);
                 if (audioClip != null) {
                     item.dropSFX = audioClip;
                 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,5 +1,6 @@
 ﻿using BepInEx;
 using HarmonyLib;
+using System.IO;
 
 namespace LethalClunk
 {
@@ -10,6 +11,8 @@ namespace LethalClunk
         private readonly Harmony harmony = new Harmony(PluginInfo.PLUGIN_NAME);
         private readonly BepInEx.Logging.ManualLogSource logger;
 
+        internal static Plugin? Instance;
+
         public Plugin()
         {
             logger = BepInEx.Logging.Logger.CreateLogSource(PluginInfo.PLUGIN_NAME);
@@ -17,6 +20,11 @@ namespace LethalClunk
 
         public void Awake()
         {
+            if (Instance == null)
+            {
+                Instance = this;
+            }
+
             harmony.PatchAll();
             logger.LogInfo($"Plugin {PluginInfo.PLUGIN_GUID} is loaded!");
         }


### PR DESCRIPTION
Enables r2modman support. Changes the reference to the WAV file to relative to the DLL instead of the BepInEx plugin folder. r2modman puts everything in its own nested folders, breaking the relationship between the plugins folder and any internal files.